### PR TITLE
ログイン画面と認証関係の処理作成

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,13 +1,18 @@
-src/node_modules
+/src/node_modules
 /.pnp
-.pnp.js
+.pnp.*
+.yarn/*
+!.yarn/patches
+!.yarn/plugins
+!.yarn/releases
+!.yarn/versions
 
 /coverage
 
-src/.next/
-src/out/
+/src/.next/
+/src/out/
 
-src/build
+/build
 
 .DS_Store
 *.pem
@@ -15,11 +20,12 @@ src/build
 npm-debug.log*
 yarn-debug.log*
 yarn-error.log*
+.pnpm-debug.log*
 
-.env*.local
-.env
+.env*
 
 .vercel
 
 *.tsbuildinfo
-src/next-env.d.ts
+/src/next-env.d.ts
+

--- a/src/package-lock.json
+++ b/src/package-lock.json
@@ -1277,9 +1277,9 @@
       "license": "MIT"
     },
     "node_modules/@types/node": {
-      "version": "20.17.47",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-20.17.47.tgz",
-      "integrity": "sha512-3dLX0Upo1v7RvUimvxLeXqwrfyKxUINk0EAM83swP2mlSUcwV73sZy8XhNz8bcZ3VbsfQyC/y6jRdL5tgCNpDQ==",
+      "version": "20.17.48",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-20.17.48.tgz",
+      "integrity": "sha512-KpSfKOHPsiSC4IkZeu2LsusFwExAIVGkhG1KkbaBMLwau0uMhj0fCrvyg9ddM2sAvd+gtiBJLir4LAw1MNMIaw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {

--- a/src/src/app/books/page.tsx
+++ b/src/src/app/books/page.tsx
@@ -1,0 +1,9 @@
+const BooksPage = () => {
+  return (
+    <div style={{ textAlign: 'center', marginTop: '2rem', fontSize: '1.5rem' }}>
+      本一覧です
+    </div>
+  );
+};
+
+export default BooksPage;

--- a/src/src/app/hooks/useAuth.ts
+++ b/src/src/app/hooks/useAuth.ts
@@ -1,0 +1,88 @@
+import { useState, useEffect } from 'react';
+
+type User = {
+  id: string;
+  email: string;
+  name: string;
+};
+
+type AuthState = {
+  isLoggedIn: boolean;
+  user: User | null;
+};
+
+export const useAuth = () => {
+  const [authState, setAuthState] = useState<AuthState>({
+    isLoggedIn: false,
+    user: null,
+  });
+
+  useEffect(() => {
+    const token = localStorage.getItem('token');
+    const userStr = localStorage.getItem('user');
+    
+    if (token && userStr) {
+      try {
+        const user = JSON.parse(userStr);
+        setAuthState({
+          isLoggedIn: true,
+          user,
+        });
+      } catch (error) {
+        console.error('ユーザー情報の解析に失敗しました:', error);
+        logout();
+      }
+    }
+  }, []);
+
+  const login = async (email: string, password: string) => {
+    try {
+      const response = await fetch(`${process.env.NEXT_PUBLIC_API_URL}/api/login`, {
+        method: 'POST',
+        headers: {
+          'Content-Type': 'application/json',
+        },
+        body: JSON.stringify({ email, password }),
+        credentials: 'include',
+      });
+
+      const data = await response.json();
+
+      if (!response.ok) {
+        throw new Error(data.error || 'ログインに失敗しました');
+      }
+
+      localStorage.setItem('token', data.token);
+      localStorage.setItem('user', JSON.stringify(data.user));
+      
+      setAuthState({
+        isLoggedIn: true,
+        user: data.user,
+      });
+
+      return { success: true };
+    } catch (error) {
+      console.error('ログインエラー:', error);
+      return { 
+        success: false, 
+        error: error instanceof Error ? error.message : 'ログインに失敗しました' 
+      };
+    }
+  };
+
+  const logout = () => {
+    localStorage.removeItem('token');
+    localStorage.removeItem('user');
+    setAuthState({
+      isLoggedIn: false,
+      user: null,
+    });
+  };
+
+  return {
+    isLoggedIn: authState.isLoggedIn,
+    user: authState.user,
+    login,
+    logout,
+  };
+};

--- a/src/src/app/login/page.tsx
+++ b/src/src/app/login/page.tsx
@@ -6,11 +6,12 @@ import { Button } from '../ui/button/Button';
 import { TextField } from '../ui/input/TextField';
 import Layout from '../ui/layout/Layout';
 
-const SigninForm = () => {
+const LoginForm = () => {
   const [formData, setFormData] = useState({
     email: '',
     password: ''
   });
+  const [error, setError] = useState<string>('');
 
   const handleChange = (e: React.ChangeEvent<HTMLInputElement>) => {
     const { name, value } = e.target;
@@ -18,12 +19,37 @@ const SigninForm = () => {
       ...prev,
       [name]: value
     }));
+    setError('');
   };
 
-  const handleSubmit = (e: React.FormEvent) => {
+  const handleSubmit = async (e: React.FormEvent) => {
     e.preventDefault();
-    // サインイン処理をここに実装
-    console.log('Form submitted:', formData);
+    setError('');
+  
+    try {
+      const response = await fetch(`${process.env.NEXT_PUBLIC_API_URL}/api/login`, {
+        method: 'POST',
+        headers: {
+          'Content-Type': 'application/json',
+        },
+        body: JSON.stringify(formData),
+        credentials: 'include',
+      });
+  
+      const data = await response.json();
+  
+      if (!response.ok) {
+        throw new Error(data.error || 'ログインに失敗しました');
+      }
+  
+      localStorage.setItem('token', data.token);
+      localStorage.setItem('user', JSON.stringify(data.user));
+      
+      window.location.href = '/books';
+    } catch (error) {
+      console.error('ログインエラー:', error);
+      setError(error instanceof Error ? error.message : 'ログインに失敗しました');
+    }
   };
 
   return (
@@ -32,9 +58,14 @@ const SigninForm = () => {
         <div className="sm:mx-auto sm:w-full sm:max-w-sm">
           <div className="sm:mx-auto sm:w-full sm:max-w-sm">
             <h2 className="text-center text-2xl font-bold leading-9 tracking-tight text-gray-600">
-              サインイン
+              ログイン
             </h2>
           </div>
+          {error && (
+            <div className="mt-2 text-center text-sm text-red-600">
+              {error}
+            </div>
+          )}
           <form className="space-y-5" onSubmit={handleSubmit}>
             <div>
               <TextField
@@ -55,7 +86,7 @@ const SigninForm = () => {
             <div>
               <div className="mt-6">
                 <Button
-                  value="サインイン"
+                  value="ログイン"
                   type="submit"
                 />
               </div>
@@ -76,4 +107,4 @@ const SigninForm = () => {
   );
 };
 
-export default SigninForm;
+export default LoginForm;

--- a/src/src/app/login/page.tsx
+++ b/src/src/app/login/page.tsx
@@ -5,6 +5,7 @@ import Link from 'next/link';
 import { Button } from '../ui/button/Button';
 import { TextField } from '../ui/input/TextField';
 import Layout from '../ui/layout/Layout';
+import { useAuth } from '../hooks/useAuth';
 
 const LoginForm = () => {
   const [formData, setFormData] = useState({
@@ -12,6 +13,7 @@ const LoginForm = () => {
     password: ''
   });
   const [error, setError] = useState<string>('');
+  const { login } = useAuth();
 
   const handleChange = (e: React.ChangeEvent<HTMLInputElement>) => {
     const { name, value } = e.target;
@@ -26,29 +28,12 @@ const LoginForm = () => {
     e.preventDefault();
     setError('');
   
-    try {
-      const response = await fetch(`${process.env.NEXT_PUBLIC_API_URL}/api/login`, {
-        method: 'POST',
-        headers: {
-          'Content-Type': 'application/json',
-        },
-        body: JSON.stringify(formData),
-        credentials: 'include',
-      });
-  
-      const data = await response.json();
-  
-      if (!response.ok) {
-        throw new Error(data.error || 'ログインに失敗しました');
-      }
-  
-      localStorage.setItem('token', data.token);
-      localStorage.setItem('user', JSON.stringify(data.user));
-      
+    const result = await login(formData.email, formData.password);
+    
+    if (result.success) {
       window.location.href = '/books';
-    } catch (error) {
-      console.error('ログインエラー:', error);
-      setError(error instanceof Error ? error.message : 'ログインに失敗しました');
+    } else {
+      setError(result.error || 'ログインに失敗しました');
     }
   };
 

--- a/src/src/app/signin/page.tsx
+++ b/src/src/app/signin/page.tsx
@@ -1,0 +1,79 @@
+'use client';
+
+import { useState } from 'react';
+import Link from 'next/link';
+import { Button } from '../ui/button/Button';
+import { TextField } from '../ui/input/TextField';
+import Layout from '../ui/layout/Layout';
+
+const SigninForm = () => {
+  const [formData, setFormData] = useState({
+    email: '',
+    password: ''
+  });
+
+  const handleChange = (e: React.ChangeEvent<HTMLInputElement>) => {
+    const { name, value } = e.target;
+    setFormData(prev => ({
+      ...prev,
+      [name]: value
+    }));
+  };
+
+  const handleSubmit = (e: React.FormEvent) => {
+    e.preventDefault();
+    // サインイン処理をここに実装
+    console.log('Form submitted:', formData);
+  };
+
+  return (
+    <Layout>
+      <div className="absolute inset-0 flex items-center justify-center">
+        <div className="sm:mx-auto sm:w-full sm:max-w-sm">
+          <div className="sm:mx-auto sm:w-full sm:max-w-sm">
+            <h2 className="text-center text-2xl font-bold leading-9 tracking-tight text-gray-600">
+              サインイン
+            </h2>
+          </div>
+          <form className="space-y-5" onSubmit={handleSubmit}>
+            <div>
+              <TextField
+                value="メールアドレス"
+                dataName="email"
+                onChange={handleChange}
+              />
+            </div>
+
+            <div>
+              <TextField
+                value="パスワード"
+                dataName="password"
+                onChange={handleChange}
+              />
+            </div>
+
+            <div>
+              <div className="mt-6">
+                <Button
+                  value="サインイン"
+                  type="submit"
+                />
+              </div>
+            </div>
+          </form>
+
+          <p className="mt-3 text-center text-sm text-gray-500">
+            <Link 
+              href="/signup" 
+              className="font-semibold leading-6 text-gray-600 hover:text-gray-500 transition-colors"
+            >
+              新規会員登録はこちら
+            </Link>
+          </p>
+        </div>
+      </div>
+    </Layout>
+  );
+};
+
+export default SigninForm;

--- a/src/src/app/ui/button/Button.tsx
+++ b/src/src/app/ui/button/Button.tsx
@@ -1,0 +1,37 @@
+'use client';
+
+type ButtonProps = {
+  value: string;
+  type: 'submit' | 'button' | 'reset';
+  onClick?: () => void;
+  disabled?: boolean;
+  className?: string;
+};
+
+export const Button = ({ 
+  value, 
+  type, 
+  onClick, 
+  disabled = false,
+  className = ''
+}: ButtonProps) => {
+  return (
+    <button
+      type={type}
+      onClick={onClick}
+      disabled={disabled}
+      className={`
+        flex w-full justify-center rounded-md 
+        bg-gray-600 px-3 py-1.5 text-sm font-semibold 
+        leading-6 text-white shadow-sm 
+        hover:bg-gray-500 
+        focus-visible:outline focus-visible:outline-2 
+        focus-visible:outline-offset-2
+        disabled:opacity-50 disabled:cursor-not-allowed
+        ${className}
+      `}
+    >
+      {value}
+    </button>
+  );
+};

--- a/src/src/app/ui/input/TextField.tsx
+++ b/src/src/app/ui/input/TextField.tsx
@@ -20,9 +20,9 @@ export const TextField = ({ value, dataName, onChange }: TextFieldProps) => {
       <input
         id={dataName}
         name={dataName}
-        type={dataName}
+        type={dataName === 'password' ? 'password' : 'text'}
         onChange={onChange}
-        autoComplete="current-password"
+        autoComplete={dataName === 'password' ? 'current-password' : 'off'}
         required
         className="block w-full rounded-md border-0 p-1.5 text-gray-900 shadow-sm ring-1 ring-inset ring-gray-300 placeholder:text-gray-400 focus:ring-2 focus:ring-inset focus:ring-gray-600 sm:text-sm sm:leading-6"
       />

--- a/src/src/app/ui/input/TextField.tsx
+++ b/src/src/app/ui/input/TextField.tsx
@@ -1,0 +1,31 @@
+'use client';
+
+import { ChangeEvent } from 'react';
+
+type TextFieldProps = {
+  value: string;
+  dataName: string;
+  onChange?: (e: ChangeEvent<HTMLInputElement>) => void;
+};
+
+export const TextField = ({ value, dataName, onChange }: TextFieldProps) => {
+  return (
+    <div>
+      <label 
+        htmlFor={dataName} 
+        className="block text-sm font-medium leading-6 text-gray-900"
+      >
+        {value}
+      </label>
+      <input
+        id={dataName}
+        name={dataName}
+        type={dataName}
+        onChange={onChange}
+        autoComplete="current-password"
+        required
+        className="block w-full rounded-md border-0 p-1.5 text-gray-900 shadow-sm ring-1 ring-inset ring-gray-300 placeholder:text-gray-400 focus:ring-2 focus:ring-inset focus:ring-gray-600 sm:text-sm sm:leading-6"
+      />
+    </div>
+  );
+};

--- a/src/src/app/ui/layout/Footer.tsx
+++ b/src/src/app/ui/layout/Footer.tsx
@@ -2,7 +2,6 @@
 
 type FooterProps = {
   className?: string;
-  year?: number;
 };
 
 export const Footer = ({ 

--- a/src/src/app/ui/layout/Footer.tsx
+++ b/src/src/app/ui/layout/Footer.tsx
@@ -1,0 +1,20 @@
+'use client';
+
+type FooterProps = {
+  className?: string;
+  year?: number;
+};
+
+export const Footer = ({ 
+  className = '',
+}: FooterProps) => {
+  return (
+    <footer className={`bg-gray-800 p-4 text-white ${className}`}>
+      <div className="container mx-auto">
+        <p className="text-center">
+          &copy; 2025 Runteq_sayaka
+        </p>
+      </div>
+    </footer>
+  );
+};

--- a/src/src/app/ui/layout/Footer.tsx
+++ b/src/src/app/ui/layout/Footer.tsx
@@ -1,14 +1,8 @@
 'use client';
 
-type FooterProps = {
-  className?: string;
-};
-
-export const Footer = ({ 
-  className = '',
-}: FooterProps) => {
+export const Footer = () => {
   return (
-    <footer className={`bg-gray-800 p-4 text-white ${className}`}>
+    <footer className={`bg-gray-800 p-4 text-white`}>
       <div className="container mx-auto">
         <p className="text-center">
           &copy; 2025 Runteq_sayaka

--- a/src/src/app/ui/layout/Header.tsx
+++ b/src/src/app/ui/layout/Header.tsx
@@ -48,10 +48,10 @@ export const Header = ({ className = '' }: HeaderProps) => {
         </div>
         <div>
           <Link 
-            href="/signin" 
+            href="/login" 
             className="block md:inline-block hover:text-gray-400 transition-colors"
           >
-            サインイン
+            ログイン
           </Link>
         </div>
       </nav>

--- a/src/src/app/ui/layout/Header.tsx
+++ b/src/src/app/ui/layout/Header.tsx
@@ -1,0 +1,60 @@
+'use client';
+
+import Link from 'next/link';
+import { useState } from 'react';
+
+type HeaderProps = {
+  className?: string;
+};
+
+export const Header = ({ className = '' }: HeaderProps) => {
+  const [isMenuOpen, setIsMenuOpen] = useState(false);
+
+  return (
+    <header className={`bg-gray-800 p-4 text-white flex justify-between items-center z-50 ${className}`}>
+      <div>
+        <Link 
+          href="/books" 
+          className="text-2xl font-bold hover:text-gray-400 transition-colors"
+        >
+          Booking
+        </Link>
+      </div>
+
+      <nav className={`
+        ${isMenuOpen ? 'block' : 'hidden'} 
+        md:flex md:items-center
+        absolute md:relative
+        top-16 md:top-0
+        left-0 right-0
+        bg-gray-800 md:bg-transparent
+        p-4 md:p-0
+      `}>
+        <div>
+          <Link 
+            href="/books" 
+            className="block md:inline-block mr-3 hover:text-gray-400 transition-colors"
+          >
+            本の一覧
+          </Link>
+        </div>
+        <div>
+          <Link 
+            href="/books/register" 
+            className="block md:inline-block mr-3 hover:text-gray-400 transition-colors"
+          >
+            本の登録
+          </Link>
+        </div>
+        <div>
+          <Link 
+            href="/signin" 
+            className="block md:inline-block hover:text-gray-400 transition-colors"
+          >
+            サインイン
+          </Link>
+        </div>
+      </nav>
+    </header>
+  );
+};

--- a/src/src/app/ui/layout/Header.tsx
+++ b/src/src/app/ui/layout/Header.tsx
@@ -1,7 +1,7 @@
 'use client';
 
 import Link from 'next/link';
-import { useState } from 'react';
+import { useState, useEffect } from 'react';
 
 type HeaderProps = {
   className?: string;
@@ -9,6 +9,19 @@ type HeaderProps = {
 
 export const Header = ({ className = '' }: HeaderProps) => {
   const [isMenuOpen, setIsMenuOpen] = useState(false);
+  const [isLoggedIn, setIsLoggedIn] = useState(false);
+
+  useEffect(() => {
+    const token = localStorage.getItem('token');
+    setIsLoggedIn(!!token);
+  }, []);
+
+  const handleLogout = () => {
+    localStorage.removeItem('token');
+    localStorage.removeItem('user');
+    setIsLoggedIn(false);
+    window.location.href = '/login';
+  };
 
   return (
     <header className={`bg-gray-800 p-4 text-white flex justify-between items-center z-50 ${className}`}>
@@ -47,12 +60,21 @@ export const Header = ({ className = '' }: HeaderProps) => {
           </Link>
         </div>
         <div>
-          <Link 
-            href="/login" 
-            className="block md:inline-block hover:text-gray-400 transition-colors"
-          >
-            ログイン
-          </Link>
+          {isLoggedIn ? (
+            <button
+              onClick={handleLogout}
+              className="block md:inline-block hover:text-gray-400 transition-colors"
+            >
+              ログアウト
+            </button>
+          ) : (
+            <Link 
+              href="/login" 
+              className="block md:inline-block hover:text-gray-400 transition-colors"
+            >
+              ログイン
+            </Link>
+          )}
         </div>
       </nav>
     </header>

--- a/src/src/app/ui/layout/Header.tsx
+++ b/src/src/app/ui/layout/Header.tsx
@@ -4,11 +4,7 @@ import Link from 'next/link';
 import { useState } from 'react';
 import { useAuth } from '../../hooks/useAuth';
 
-type HeaderProps = {
-  className?: string;
-};
-
-export const Header = ({ className = '' }: HeaderProps) => {
+export const Header = () => {
   const [isMenuOpen, setIsMenuOpen] = useState(false);
   const { isLoggedIn, logout } = useAuth();
 
@@ -18,7 +14,7 @@ export const Header = ({ className = '' }: HeaderProps) => {
   };
 
   return (
-    <header className={`bg-gray-800 p-4 text-white flex justify-between items-center z-50 ${className}`}>
+    <header className={`bg-gray-800 p-4 text-white flex justify-between items-center z-50`}>
       <div>
         <Link 
           href="/books" 

--- a/src/src/app/ui/layout/Header.tsx
+++ b/src/src/app/ui/layout/Header.tsx
@@ -16,12 +16,18 @@ export const Header = () => {
   return (
     <header className={`bg-gray-800 p-4 text-white flex justify-between items-center z-50`}>
       <div>
-        <Link 
-          href="/books" 
-          className="text-2xl font-bold hover:text-gray-400 transition-colors"
-        >
-          Booking
-        </Link>
+        {isLoggedIn ? (
+          <Link 
+            href="/books" 
+            className="text-2xl font-bold hover:text-gray-400 transition-colors"
+          >
+            Booking
+          </Link>
+        ) : (
+          <span className="text-2xl font-bold">
+            Booking
+          </span>
+        )}
       </div>
 
       <nav className={`

--- a/src/src/app/ui/layout/Header.tsx
+++ b/src/src/app/ui/layout/Header.tsx
@@ -33,22 +33,26 @@ export const Header = () => {
         bg-gray-800 md:bg-transparent
         p-4 md:p-0
       `}>
-        <div>
-          <Link 
-            href="/books" 
-            className="block md:inline-block mr-3 hover:text-gray-400 transition-colors"
-          >
-            本の一覧
-          </Link>
-        </div>
-        <div>
-          <Link 
-            href="/books/register" 
-            className="block md:inline-block mr-3 hover:text-gray-400 transition-colors"
-          >
-            本の登録
-          </Link>
-        </div>
+        {isLoggedIn && (
+          <>
+            <div>
+              <Link 
+                href="/books" 
+                className="block md:inline-block mr-3 hover:text-gray-400 transition-colors"
+              >
+                本の一覧
+              </Link>
+            </div>
+            <div>
+              <Link 
+                href="/books/register" 
+                className="block md:inline-block mr-3 hover:text-gray-400 transition-colors"
+              >
+                本の登録
+              </Link>
+            </div>
+          </>
+        )}
         <div>
           {isLoggedIn ? (
             <button

--- a/src/src/app/ui/layout/Header.tsx
+++ b/src/src/app/ui/layout/Header.tsx
@@ -1,7 +1,8 @@
 'use client';
 
 import Link from 'next/link';
-import { useState, useEffect } from 'react';
+import { useState } from 'react';
+import { useAuth } from '../../hooks/useAuth';
 
 type HeaderProps = {
   className?: string;
@@ -9,17 +10,10 @@ type HeaderProps = {
 
 export const Header = ({ className = '' }: HeaderProps) => {
   const [isMenuOpen, setIsMenuOpen] = useState(false);
-  const [isLoggedIn, setIsLoggedIn] = useState(false);
-
-  useEffect(() => {
-    const token = localStorage.getItem('token');
-    setIsLoggedIn(!!token);
-  }, []);
+  const { isLoggedIn, logout } = useAuth();
 
   const handleLogout = () => {
-    localStorage.removeItem('token');
-    localStorage.removeItem('user');
-    setIsLoggedIn(false);
+    logout();
     window.location.href = '/login';
   };
 

--- a/src/src/app/ui/layout/Layout.tsx
+++ b/src/src/app/ui/layout/Layout.tsx
@@ -1,0 +1,23 @@
+import { ReactNode } from 'react';
+import { Header } from './Header';
+import { Footer } from './Footer';
+
+type RootLayoutProps = {
+  children: ReactNode;
+};
+
+export default function RootLayout({ children }: RootLayoutProps) {
+  return (
+    <html lang="ja">
+      <body>
+        <div className="flex flex-col min-h-screen">
+          <Header />
+          <main className="flex-grow">
+            {children}
+          </main>
+          <Footer />
+        </div>
+      </body>
+    </html>
+  );
+}


### PR DESCRIPTION
# 概要
ログイン画面の作成

# 修正点
- ログイン画面の作成
- ログイン処理の作成

# 動作確認
## 前提条件
- https://github.com/sayasurvey/next15 のbug/15-api-connection-issuesブランチをクローンして環境構築をする
- サーバーを起動している状態で「http://localhost:8080」でAPIにリクエストが送れること
- 1人以上ユーザ登録していること

## 手順
- [ ] http://localhost:3000/login をブラウザで開く
- [ ] 下記のような画面が表示されることを確認する
![スクリーンショット 2025-05-23 23 56 13](https://github.com/user-attachments/assets/ed167f73-fb0b-4613-951e-c617e7795d34)
- [ ] 右上にはログインという文字のみ表示されていることを確認する
- [ ] 左上の「Booking」の文字をクリックしても何も起こらないことを確認する
- [ ] APIで作成したユーザのメールアドレスとパスワードを入力してログインボタンをクリック
- [ ] 「本一覧です」という文字が書かれたページに移動できることを確認する
- [ ] ログインのページに戻って下記のようになっていることを確認する
![スクリーンショット 2025-05-23 23 42 05](https://github.com/user-attachments/assets/0868aa8e-8e76-492a-91d9-9bc0949175dc)
- [ ] 右上に「本の一覧」、「本の登録」、「ログアウト」という文字が表示されていることを確認する
- [ ] 左上のBookingの文字をクリックすると「本一覧です」という文字が書かれたページに移動できることを確認する
- [ ] ログイン画面に戻り右上のログアウトをクリックすると画面の内容がログイン前の状態になることを確認する
