### PR TITLE
本の返却処理の実装

### DIFF
--- a/src/lib/utils.ts
+++ b/src/lib/utils.ts
@@ -41,12 +41,18 @@ export async function fetcher(url: string, options: RequestInit = {}) {
   });
 
   if (!response.ok) {
-    if (response.status === 401) {
-      deleteTokenCookie();
-      redirect('/login');
+    switch (response.status) {
+      case 401:
+        deleteTokenCookie();
+        redirect('/login');
+      case 403:
+        throw new Error('権限がありません');
+      case 404:
+        throw new Error('ページが見つかりません');
+      default:
+        const errorData = await response.json().catch(() => ({}));
+        throw new Error(errorData.message);
     }
-    const errorData = await response.json().catch(() => ({}));
-    throw new Error(errorData.message || 'リクエストに失敗しました');
   }
 
   return response.json();

--- a/src/src/app/books/borrowed/page.tsx
+++ b/src/src/app/books/borrowed/page.tsx
@@ -1,0 +1,13 @@
+import { BorrowedBookList } from '../../ui/books/borrowed/BorrowedBookList';
+import { Title }  from '../../ui/utils/Title';
+
+const BorrowedBooksPage = () => {
+  return (
+    <div>
+      <Title value="借りた本の一覧"/>
+      <BorrowedBookList />
+    </div>
+  );
+}
+
+export default BorrowedBooksPage;

--- a/src/src/app/ui/books/borrowed/BorrowedBookCard.tsx
+++ b/src/src/app/ui/books/borrowed/BorrowedBookCard.tsx
@@ -1,0 +1,45 @@
+"use client";
+
+import { ReactElement, useState } from 'react';
+
+interface BorrowedBook {
+  id: number;
+  imageUrl: string;
+  title: string;
+  checkoutDate: string;
+  returnDueDate: string;
+}
+
+interface BookCardProps extends BorrowedBook {
+  onReturnSuccess: () => void;
+}
+
+export function BorrowedBookCard({ id, imageUrl, title, checkoutDate, returnDueDate, onReturnSuccess }: BookCardProps): ReactElement {
+  const [isModalOpen, setIsModalOpen] = useState(false);
+
+  const handleReturnClick = () => {
+
+  };
+
+  return (
+    <div className='border border-bd rounded-lg'>
+      <div className="group relative aspect-h-1 aspect-w-1 w-full overflow-hidden bg-gray-200 xl:aspect-h-8 xl:aspect-w-7">
+        <img
+          src={imageUrl}
+          className="sm:h-full md:h-[25rem] lg:h-[20rem] xl:h-[20rem] w-full rounded-t-lg object-cover object-center group-hover:opacity-25"
+        />
+        <div className='absolute top-5 left-5 opacity-0 group-hover:opacity-100'>
+          <p>タイトル:</p>
+          <p>　{title}</p>
+          <p>貸出日:</p>
+          <p>　{checkoutDate}</p>
+          <p>返却予定日:</p>
+          <p>　{returnDueDate}</p>
+        </div>
+      </div>
+      <div className='flex rounded-lg'>
+        <p onClick={handleReturnClick} className={`py-1 w-full text-center border-r border-bd cursor-pointer`}>返却</p>
+      </div>
+    </div>
+  );
+}

--- a/src/src/app/ui/books/borrowed/BorrowedBookCard.tsx
+++ b/src/src/app/ui/books/borrowed/BorrowedBookCard.tsx
@@ -23,18 +23,15 @@ export function BorrowedBookCard({ id, imageUrl, title, checkoutDate, returnDueD
     
     if (isConfirmed) {
       try {
-        const response = await fetcher('api/books/return', {
+        await fetcher('api/books/return', {
           method: 'POST',
           body: JSON.stringify({
             'borrowedBookId': id
           }),
         });
 
-        if (response.status === 200) {
-          onReturnSuccess();
-        } else {
-          alert('返却処理に失敗しました。');
-        }
+        onReturnSuccess();
+        alert('返却処理が完了しました。');
       } catch (error) {
         console.error('返却処理中にエラーが発生しました:', error);
         alert('返却処理中にエラーが発生しました。');

--- a/src/src/app/ui/books/borrowed/BorrowedBookCard.tsx
+++ b/src/src/app/ui/books/borrowed/BorrowedBookCard.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { ReactElement, useState } from 'react';
+import { fetcher } from '../../../../../lib/utils';
 
 interface BorrowedBook {
   id: number;
@@ -17,8 +18,28 @@ interface BookCardProps extends BorrowedBook {
 export function BorrowedBookCard({ id, imageUrl, title, checkoutDate, returnDueDate, onReturnSuccess }: BookCardProps): ReactElement {
   const [isModalOpen, setIsModalOpen] = useState(false);
 
-  const handleReturnClick = () => {
+  const handleReturnClick = async () => {
+    const isConfirmed = window.confirm('本の返却が完了しましたか？');
+    
+    if (isConfirmed) {
+      try {
+        const response = await fetcher('api/books/return', {
+          method: 'POST',
+          body: JSON.stringify({
+            'borrowedBookId': id
+          }),
+        });
 
+        if (response.status === 200) {
+          onReturnSuccess();
+        } else {
+          alert('返却処理に失敗しました。');
+        }
+      } catch (error) {
+        console.error('返却処理中にエラーが発生しました:', error);
+        alert('返却処理中にエラーが発生しました。');
+      }
+    }
   };
 
   return (

--- a/src/src/app/ui/books/borrowed/BorrowedBookList.tsx
+++ b/src/src/app/ui/books/borrowed/BorrowedBookList.tsx
@@ -37,7 +37,7 @@ export const BorrowedBookList: React.FC = () => {
       });
 
       const data: BorrowedBooksResponse = await fetcher(`api/books/borrowed?${params.toString()}`);
-      console.log(data);
+
       setBorrowedBooks(data.borrowedBooks);
       setLastPage(data.lastPage);
     } catch (err) {

--- a/src/src/app/ui/books/borrowed/BorrowedBookList.tsx
+++ b/src/src/app/ui/books/borrowed/BorrowedBookList.tsx
@@ -1,32 +1,20 @@
 "use client";
 
 import { useState, useEffect } from 'react';
-import { fetcher } from '../../../../lib/utils';
-import { BookCard } from './BookCard';
-import { Pagination } from '../utils/Pagination';
+import { fetcher } from '../../../../../lib/utils';
+import { BorrowedBookCard } from './BorrowedBookCard';
+import { Pagination } from '../../utils/Pagination';
 
-interface Book {
+interface BorrowedBooks {
   id: number;
   imageUrl: string;
   title: string;
-  loanable: boolean;
-  user: {
-    id: number;
-    name: string;
-  };
+  checkoutDate: string;
+  returnDueDate: string;
 }
 
-interface BooksResponse {
-  books: Array<{
-    id: number;
-    title: string;
-    imageUrl: string;
-    loanable: boolean;
-    user: {
-      id: number;
-      name: string;
-    };
-  }>;
+interface BorrowedBooksResponse {
+  borrowedBooks: Array<BorrowedBooks>;
   currentPage: number;
   lastPage: number;
   perPage: number;
@@ -34,8 +22,8 @@ interface BooksResponse {
 
 const PER_PAGE = 50;
 
-export const BookList: React.FC = () => {
-  const [books, setBooks] = useState<Book[]>([]);
+export const BorrowedBookList: React.FC = () => {
+  const [borrowedBooks, setBorrowedBooks] = useState<BorrowedBooks[]>([]);
   const [isLoading, setIsLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
   const [currentPage, setCurrentPage] = useState(1);
@@ -48,11 +36,12 @@ export const BookList: React.FC = () => {
         perPage: PER_PAGE.toString()
       });
 
-      const data: BooksResponse = await fetcher(`api/books?${params.toString()}`);
-      setBooks(data.books);
+      const data: BorrowedBooksResponse = await fetcher(`api/books/borrowed?${params.toString()}`);
+      console.log(data);
+      setBorrowedBooks(data.borrowedBooks);
       setLastPage(data.lastPage);
     } catch (err) {
-      console.error('本一覧の取得に失敗しました:', err);
+      console.error('借りた本の一覧の取得に失敗しました:', err);
       setError(err instanceof Error ? err.message : '予期せぬエラーが発生しました');
     } finally {
       setIsLoading(false);
@@ -71,11 +60,11 @@ export const BookList: React.FC = () => {
     <div className="bg-white">
       <div className="mx-auto max-w-2xl px-4 py-16 sm:px-6 sm:py-8 lg:max-w-7xl lg:px-8">
         <div className="grid grid-cols-1 gap-x-6 gap-y-10 sm:grid-cols-2 lg:grid-cols-4 xl:grid-cols-5 xl:gap-x-8">
-          {books.map((book) => (
-            <BookCard 
+          {borrowedBooks.map((book) => (
+            <BorrowedBookCard 
               key={book.id} 
               {...book}
-              onBorrowSuccess={fetchBooks}
+              onReturnSuccess={fetchBooks}
             />
           ))}
         </div>

--- a/src/src/app/ui/layouts/Header.tsx
+++ b/src/src/app/ui/layouts/Header.tsx
@@ -59,6 +59,14 @@ export const Header = () => {
                 本の登録
               </Link>
             </div>
+            <div>
+              <Link 
+                href="/books/borrowed" 
+                className="block md:inline-block mr-3 hover:text-gray-400 transition-colors font-bold"
+              >
+                借りた本
+              </Link>
+            </div>
           </>
         )}
         <div>


### PR DESCRIPTION
# 概要
本の返却処理の作成

# 修正点
- 借りた本の一覧
- 借りた本のコンポーネント作成
- 返却APIとの連携処理
- エラーハンドリングの修正

# 動作確認
## 前提条件
- 借りた本が1冊以上あること
- APIのブランチが「feature/11-book-loan-and-return」であること

## 手順
### 返却処理ができること
- 「http://localhost:3000/books/borrowed 」を開く
- 返却する本の返却ボタンを押す
![スクリーンショット 2025-06-01 2 26 43](https://github.com/user-attachments/assets/b152484b-9a2a-4db5-83dd-bdf52b95e401)
- 「本の返却が完了しましたか？」というダイアログが表示されるのでOKをクリック
![スクリーンショット 2025-06-01 2 28 55](https://github.com/user-attachments/assets/ca06ae49-5df3-4fd7-bdc1-11695b337579)
- 「返却が完了しました」というアラートが表示されるのでOKをクリック
- 借りた本の一覧から返却した本が消えていることを確認する
- 本の一覧に移動し、返却した本の借りるボタンが黒字になっていることを確認する